### PR TITLE
Add profile and settings pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ Any file inside `src/partials` is automatically registered, so these partials ar
 
 This repository includes sample pages for each sidebar item:
 
-- `feed.html`
+- `index.html` (feed)
 - `map.html`
 - `friends.html`
 - `groups.html`
 - `market.html`
 - `calendar.html`
+- `profile.html`
+- `settings.html`
+- `messages.html`
 
 Each page uses the partials so you can use them as a starting point when creating additional pages.
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Document</title>
+  <title>Feed</title>
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4.6.2/dist/full.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
@@ -17,8 +17,68 @@
       {{> navbar }}
 
       <div class="p-4">
-        <h1 class="text-2xl">Willkommen!</h1>
-        <p>Dein Hauptinhalt steht hier.</p>
+        <h1 class="text-2xl mb-4">Feed</h1>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/40/40" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Alice</h2>
+              </div>
+              <p>Enjoying the sunny weather today!</p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/41/41" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Bob</h2>
+              </div>
+              <p>Just finished a great book on web design.</p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/42/42" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Clara</h2>
+              </div>
+              <p>Here is a snapshot from my recent trip.</p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/43/43" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Daniel</h2>
+              </div>
+              <p>Does anyone have podcast recommendations?</p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/44/44" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Elena</h2>
+              </div>
+              <p>Baking some cookies this weekend!</p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="mb-2 flex items-center gap-2">
+                <img src="https://placekitten.com/45/45" class="h-10 w-10 rounded-full" alt="Avatar" />
+                <h2 class="card-title text-sm">Fred</h2>
+              </div>
+              <p>Started learning a new programming language.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/messages.html
+++ b/messages.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Messages</title>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4.6.2/dist/full.css" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
+</head>
+
+<body>
+  <div class="drawer">
+    <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+    <div class="drawer-content">
+      {{> navbar }}
+
+      <div class="p-4">
+        <h1 class="text-2xl">Messages</h1>
+        <p>Check your latest conversations here.</p>
+      </div>
+    </div>
+
+    {{> sidebar }}
+  </div>
+</body>
+
+</html>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile</title>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4.6.2/dist/full.css" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
+</head>
+
+<body>
+  <div class="drawer">
+    <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+    <div class="drawer-content">
+      {{> navbar }}
+
+      <div class="p-4">
+        <h1 class="text-2xl">Profile</h1>
+        <p>View and edit your personal information.</p>
+      </div>
+    </div>
+
+    {{> sidebar }}
+  </div>
+</body>
+
+</html>

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings</title>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4.6.2/dist/full.css" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
+</head>
+
+<body>
+  <div class="drawer">
+    <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+    <div class="drawer-content">
+      {{> navbar }}
+
+      <div class="p-4">
+        <h1 class="text-2xl">Settings</h1>
+        <p>Manage your account preferences.</p>
+      </div>
+    </div>
+
+    {{> sidebar }}
+  </div>
+</body>
+
+</html>

--- a/src/partials/navbar.html
+++ b/src/partials/navbar.html
@@ -46,7 +46,7 @@
         <span class="badge badge-xs badge-primary indicator-item"></span>
       </div>
     </button>
-    <button class="btn btn-ghost btn-circle">
+    <a href="messages.html" class="btn btn-ghost btn-circle">
       <div class="indicator">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
           class="size-6">
@@ -55,7 +55,7 @@
         </svg>
         <span class="badge badge-xs badge-primary indicator-item"></span>
       </div>
-    </button>
+    </a>
     <div class="dropdown dropdown-end">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
         <div class="w-10 rounded-full">
@@ -63,8 +63,8 @@
         </div>
       </div>
       <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow">
-        <li><a>Profile</a></li>
-        <li><a>Settings</a></li>
+        <li><a href="profile.html">Profile</a></li>
+        <li><a href="settings.html">Settings</a></li>
         <li><a>Logout</a></li>
       </ul>
     </div>

--- a/src/partials/sidebar.html
+++ b/src/partials/sidebar.html
@@ -1,7 +1,7 @@
 <div class="drawer-side">
   <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
   <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
-    <li><a href="feed.html">Feed</a></li>
+    <li><a href="index.html">Feed</a></li>
     <li><a href="map.html">Map</a></li>
     <li><a href="friends.html">Friends</a></li>
     <li><a href="groups.html">Groups</a></li>


### PR DESCRIPTION
## Summary
- create user pages for Profile and Settings
- replace index.html with feed layout
- add new Messages page and link from navbar
- link sidebar feed to index page
- document pages in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f0ed5bbf4832792d3c3a533d4db44