### PR TITLE
Add DaisyUI examples across pages

### DIFF
--- a/prototype/src/components/Navbar.vue
+++ b/prototype/src/components/Navbar.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="navbar bg-base-100 z-20 shadow-lg flex">
-  <div class="navbar bg-base-100 shadow-lg flex">
+  <div class="navbar bg-base-100 shadow-lg flex z-20">
     <div class="flex-none">
       <!-- Toggle button for sidebar -->
       <button class="btn btn-square btn-ghost" @click="emit('toggle-sidebar')">

--- a/prototype/src/pages/CalendarPage.vue
+++ b/prototype/src/pages/CalendarPage.vue
@@ -1,5 +1,31 @@
-<template>
-  <div class="p-4">Calendar Page</div>
-</template>
+<script setup lang="ts">
+interface Event {
+  date: string
+  title: string
+  description: string
+}
 
-<script setup lang="ts"></script>
+const events: Event[] = [
+  { date: '2024-06-10', title: 'Meetup', description: 'Local community gathering' },
+  { date: '2024-06-15', title: 'Workshop', description: 'Vue.js basics' },
+  { date: '2024-06-22', title: 'Hackathon', description: 'Build cool projects together' }
+]
+</script>
+
+<template>
+  <div class="p-4 space-y-4">
+    <div
+      v-for="event in events"
+      :key="event.date"
+      class="collapse collapse-arrow bg-base-100 shadow"
+    >
+      <input type="checkbox" />
+      <div class="collapse-title font-medium">
+        {{ event.date }} - {{ event.title }}
+      </div>
+      <div class="collapse-content">
+        <p>{{ event.description }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/FriendsPage.vue
+++ b/prototype/src/pages/FriendsPage.vue
@@ -1,5 +1,48 @@
-<template>
-  <div class="p-4">Friends Page</div>
-</template>
+<script setup lang="ts">
+interface Friend {
+  name: string
+  avatar: string
+  status: string
+}
 
-<script setup lang="ts"></script>
+const friends: Friend[] = [
+  {
+    name: 'Alice',
+    avatar: 'https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp',
+    status: 'online'
+  },
+  {
+    name: 'Bob',
+    avatar: 'https://img.daisyui.com/images/stock/photo-1506794778202-cad84cf45f1d.webp',
+    status: 'offline'
+  },
+  {
+    name: 'Charlie',
+    avatar: 'https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.webp',
+    status: 'busy'
+  }
+]
+</script>
+
+<template>
+  <div class="p-4">
+    <ul class="space-y-2">
+      <li
+        v-for="friend in friends"
+        :key="friend.name"
+        class="flex items-center gap-4 rounded-box bg-base-100 p-3 shadow"
+      >
+        <img
+          :src="friend.avatar"
+          :alt="friend.name"
+          class="h-12 w-12 rounded-full"
+        />
+        <div class="flex-1">
+          <div class="font-semibold">{{ friend.name }}</div>
+          <div class="text-sm opacity-60">{{ friend.status }}</div>
+        </div>
+        <button class="btn btn-sm">Message</button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/prototype/src/pages/GroupsPage.vue
+++ b/prototype/src/pages/GroupsPage.vue
@@ -1,5 +1,46 @@
-<template>
-  <div class="p-4">Groups Page</div>
-</template>
+<script setup lang="ts">
+interface Group {
+  name: string
+  description: string
+  banner: string
+}
 
-<script setup lang="ts"></script>
+const groups: Group[] = [
+  {
+    name: 'Hiking Club',
+    description: 'Join us for weekly adventures in nature.',
+    banner: 'https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg'
+  },
+  {
+    name: 'Book Lovers',
+    description: 'Discuss your favourite reads with others.',
+    banner: 'https://img.daisyui.com/images/stock/photo-1523475496153-3d6cc2959a31.webp'
+  },
+  {
+    name: 'Cooking Fans',
+    description: 'Share and learn new recipes every week.',
+    banner: 'https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp'
+  }
+]
+</script>
+
+<template>
+  <div class="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      v-for="group in groups"
+      :key="group.name"
+      class="card bg-base-100 shadow-sm"
+    >
+      <figure>
+        <img :src="group.banner" :alt="group.name" />
+      </figure>
+      <div class="card-body">
+        <h2 class="card-title">{{ group.name }}</h2>
+        <p>{{ group.description }}</p>
+        <div class="card-actions justify-end">
+          <button class="btn btn-sm">Join</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/HomePage.vue
+++ b/prototype/src/pages/HomePage.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="p-4">
+  <div class="p-4 space-y-4">
+    <div class="hero rounded-box bg-base-200">
+      <div class="hero-content text-center">
+        <div class="max-w-md">
+          <h1 class="text-3xl font-bold">Welcome</h1>
+          <p class="py-2">Check out the latest posts below.</p>
+        </div>
+      </div>
+    </div>
     <div class="max-w-8xl w-full">
       <Feed />
     </div>

--- a/prototype/src/pages/MapPage.vue
+++ b/prototype/src/pages/MapPage.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="p-4 h-full">
-    <div id="map" class="w-full h-full rounded-box"></div>
+  <div class="p-4 h-full flex flex-col">
+    <div class="card flex-1 bg-base-100 shadow">
+      <div id="map" class="h-full w-full rounded-box"></div>
+    </div>
   </div>
 </template>
 

--- a/prototype/src/pages/MarketPage.vue
+++ b/prototype/src/pages/MarketPage.vue
@@ -1,5 +1,44 @@
-<template>
-  <div class="p-4">Market Page</div>
-</template>
+<script setup lang="ts">
+interface Item {
+  name: string
+  price: string
+  image: string
+}
 
-<script setup lang="ts"></script>
+const items: Item[] = [
+  {
+    name: 'Mountain Bike',
+    price: '$500',
+    image: 'https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg'
+  },
+  {
+    name: 'Coffee Maker',
+    price: '$75',
+    image: 'https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.jpg'
+  },
+  {
+    name: 'Headphones',
+    price: '$120',
+    image: 'https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp'
+  }
+]
+</script>
+
+<template>
+  <div class="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      v-for="item in items"
+      :key="item.name"
+      class="card bg-base-100 shadow-sm"
+    >
+      <figure><img :src="item.image" :alt="item.name" /></figure>
+      <div class="card-body">
+        <h2 class="card-title">{{ item.name }}</h2>
+        <p class="text-primary font-semibold">{{ item.price }}</p>
+        <div class="card-actions justify-end">
+          <button class="btn btn-sm">Buy</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/MessagesPage.vue
+++ b/prototype/src/pages/MessagesPage.vue
@@ -1,5 +1,46 @@
-<template>
-  <div class="p-4">Messages Page</div>
-</template>
+<script setup lang="ts">
+import { ref } from 'vue'
 
-<script setup lang="ts"></script>
+interface Message {
+  from: 'me' | 'them'
+  text: string
+}
+
+const messages = ref<Message[]>([
+  { from: 'them', text: 'Hi there!' },
+  { from: 'me', text: 'Hello!' },
+  { from: 'them', text: 'How are you?' }
+])
+const newMsg = ref('')
+
+function send() {
+  if (!newMsg.value) return
+  messages.value.push({ from: 'me', text: newMsg.value })
+  newMsg.value = ''
+}
+</script>
+
+<template>
+  <div class="p-4 flex flex-col gap-4 h-full">
+    <div class="flex-1 overflow-y-auto space-y-2">
+      <div
+        v-for="(msg, i) in messages"
+        :key="i"
+        class="chat"
+        :class="msg.from === 'me' ? 'chat-end' : 'chat-start'"
+      >
+        <div class="chat-bubble">{{ msg.text }}</div>
+      </div>
+    </div>
+    <div class="join">
+      <input
+        v-model="newMsg"
+        type="text"
+        placeholder="Type a message"
+        class="input input-bordered join-item flex-1"
+        @keyup.enter="send"
+      />
+      <button class="btn join-item" @click="send">Send</button>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/ProfilePage.vue
+++ b/prototype/src/pages/ProfilePage.vue
@@ -1,5 +1,24 @@
-<template>
-  <div class="p-4">Profile Page</div>
-</template>
+<script setup lang="ts">
+const user = {
+  name: 'John Doe',
+  bio: 'Enthusiastic traveler and photographer.',
+  avatar: 'https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp'
+}
+</script>
 
-<script setup lang="ts"></script>
+<template>
+  <div class="p-4 flex justify-center">
+    <div class="card w-full max-w-md bg-base-100 shadow">
+      <figure class="px-10 pt-10">
+        <img :src="user.avatar" :alt="user.name" class="rounded-full w-32" />
+      </figure>
+      <div class="card-body items-center text-center">
+        <h2 class="card-title">{{ user.name }}</h2>
+        <p>{{ user.bio }}</p>
+        <div class="card-actions">
+          <button class="btn btn-sm">Follow</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/SettingsPage.vue
+++ b/prototype/src/pages/SettingsPage.vue
@@ -1,5 +1,24 @@
-<template>
-  <div class="p-4">Settings Page</div>
-</template>
+<script setup lang="ts">
+import { ref } from 'vue'
 
-<script setup lang="ts"></script>
+const notifications = ref(true)
+const darkMode = ref(false)
+</script>
+
+<template>
+  <form class="p-4 space-y-4 max-w-md">
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">Enable notifications</span>
+        <input type="checkbox" v-model="notifications" class="toggle" />
+      </label>
+    </div>
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">Dark mode</span>
+        <input type="checkbox" v-model="darkMode" class="toggle" />
+      </label>
+    </div>
+    <button class="btn btn-primary btn-sm" type="submit">Save</button>
+  </form>
+</template>


### PR DESCRIPTION
## Summary
- embed DaisyUI hero on homepage
- add friend list, groups catalog, marketplace and other sample UI elements
- wrap map and build simple profile, settings and messages views
- fix navbar markup

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68633877fad88327837b76b253f27f5f