### PR TITLE
Add DaisyUI examples across pages

### DIFF
--- a/prototype/public/posts.json
+++ b/prototype/public/posts.json
@@ -1,47 +1,159 @@
-[
-  {
-    "banner": "https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg",
-    "title": "Hiking Adventure",
-    "text": "Exploring the beautiful mountain trails today!",
-    "user": {
-      "username": "alice",
-      "profile": "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
+{
+  "posts": [
+    {
+      "banner": "https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg",
+      "title": "Hiking Adventure",
+      "text": "Exploring the beautiful mountain trails today!",
+      "user": {
+        "username": "alice",
+        "profile": "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
+      }
+    },
+    {
+      "banner": "https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp",
+      "title": "Delicious Breakfast",
+      "text": "Nothing beats homemade pancakes on a Sunday morning.",
+      "user": {
+        "username": "bob",
+        "profile": "https://img.daisyui.com/images/stock/photo-1506794778202-cad84cf45f1d.webp"
+      }
+    },
+    {
+      "banner": "https://img.daisyui.com/images/stock/photo-1523475496153-3d6cc2959a31.webp",
+      "title": "City Lights",
+      "text": "Captured the skyline during my evening walk downtown.",
+      "user": {
+        "username": "charlie",
+        "profile": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.webp"
+      }
+    },
+    {
+      "banner": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.jpg",
+      "title": "Road Trip",
+      "text": "Starting our cross-country journey today!",
+      "user": {
+        "username": "diana",
+        "profile": "https://img.daisyui.com/images/stock/photo-1494790108377-be9c29b29330.webp"
+      }
+    },
+    {
+      "banner": "https://img.daisyui.com/images/stock/photo-1525164761484-f3c3b1f1cb4b.webp",
+      "title": "Garden Harvest",
+      "text": "Fresh veggies straight from the backyard garden.",
+      "user": {
+        "username": "edgar",
+        "profile": "https://img.daisyui.com/images/stock/photo-1517841905240-472988babdf9.webp"
+      }
     }
+  ],
+  "friends": [
+    {
+      "name": "Alice",
+      "avatar": "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp",
+      "status": "online"
+    },
+    {
+      "name": "Bob",
+      "avatar": "https://img.daisyui.com/images/stock/photo-1506794778202-cad84cf45f1d.webp",
+      "status": "offline"
+    },
+    {
+      "name": "Charlie",
+      "avatar": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.webp",
+      "status": "busy"
+    }
+  ],
+  "groups": [
+    {
+      "name": "Hiking Club",
+      "description": "Join us for weekly adventures in nature.",
+      "banner": "https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg"
+    },
+    {
+      "name": "Book Lovers",
+      "description": "Discuss your favourite reads with others.",
+      "banner": "https://img.daisyui.com/images/stock/photo-1523475496153-3d6cc2959a31.webp"
+    },
+    {
+      "name": "Cooking Fans",
+      "description": "Share and learn new recipes every week.",
+      "banner": "https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp"
+    }
+  ],
+  "items": [
+    {
+      "name": "Mountain Bike",
+      "price": "$500",
+      "image": "https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.jpg"
+    },
+    {
+      "name": "Coffee Maker",
+      "price": "$75",
+      "image": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.jpg"
+    },
+    {
+      "name": "Headphones",
+      "price": "$120",
+      "image": "https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp"
+    }
+  ],
+  "events": [
+    {
+      "date": "2024-06-10",
+      "title": "Meetup",
+      "description": "Local community gathering"
+    },
+    {
+      "date": "2024-06-15",
+      "title": "Workshop",
+      "description": "Vue.js basics"
+    },
+    {
+      "date": "2024-06-22",
+      "title": "Hackathon",
+      "description": "Build cool projects together"
+    }
+  ],
+  "messages": [
+    { "from": "them", "text": "Hi there!" },
+    { "from": "me", "text": "Hello!" },
+    { "from": "them", "text": "How are you?" }
+  ],
+  "user": {
+    "name": "John Doe",
+    "bio": "Enthusiastic traveler and photographer.",
+    "avatar": "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
   },
-  {
-    "banner": "https://img.daisyui.com/images/stock/photo-1508921912186-1d1a45ebb3c1.webp",
-    "title": "Delicious Breakfast",
-    "text": "Nothing beats homemade pancakes on a Sunday morning.",
-    "user": {
-      "username": "bob",
-      "profile": "https://img.daisyui.com/images/stock/photo-1506794778202-cad84cf45f1d.webp"
+  "locations": [
+    {
+      "id": 1,
+      "coordinates": [13.404954, 52.520008],
+      "title": "Berlin",
+      "description": "Berlin is the capital of Germany"
+    },
+    {
+      "id": 2,
+      "coordinates": [11.581981, 48.135125],
+      "title": "Munich",
+      "description": "Munich is a city in Bavaria"
+    },
+    {
+      "id": 3,
+      "coordinates": [9.993682, 53.551086],
+      "title": "Hamburg",
+      "description": "Hamburg is a port city"
+    },
+    {
+      "id": 4,
+      "coordinates": [8.682127, 50.110924],
+      "title": "Frankfurt",
+      "description": "Frankfurt is a financial hub"
+    },
+    {
+      "id": 5,
+      "coordinates": [6.960279, 50.937531],
+      "title": "Cologne",
+      "description": "Cologne is famous for its cathedral"
     }
-  },
-  {
-    "banner": "https://img.daisyui.com/images/stock/photo-1523475496153-3d6cc2959a31.webp",
-    "title": "City Lights",
-    "text": "Captured the skyline during my evening walk downtown.",
-    "user": {
-      "username": "charlie",
-      "profile": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.webp"
-    }
-  },
-  {
-    "banner": "https://img.daisyui.com/images/stock/photo-1529626455594-4ff0802cfb7e.jpg",
-    "title": "Road Trip",
-    "text": "Starting our cross-country journey today!",
-    "user": {
-      "username": "diana",
-      "profile": "https://img.daisyui.com/images/stock/photo-1494790108377-be9c29b29330.webp"
-    }
-  },
-  {
-    "banner": "https://img.daisyui.com/images/stock/photo-1525164761484-f3c3b1f1cb4b.webp",
-    "title": "Garden Harvest",
-    "text": "Fresh veggies straight from the backyard garden.",
-    "user": {
-      "username": "edgar",
-      "profile": "https://img.daisyui.com/images/stock/photo-1517841905240-472988babdf9.webp"
-    }
-  }
-]
+  ]
+}

--- a/prototype/src/components/Feed.vue
+++ b/prototype/src/components/Feed.vue
@@ -17,7 +17,8 @@ onMounted(async () => {
   try {
     const res = await fetch('/posts.json')
     if (res.ok) {
-      posts.value = await res.json()
+      const data = await res.json()
+      posts.value = data.posts ?? data
     } else {
       console.error('Failed to load posts')
     }

--- a/prototype/src/components/Navbar.vue
+++ b/prototype/src/components/Navbar.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="navbar bg-base-100 z-20 shadow-lg flex">
-  <div class="navbar bg-base-100 shadow-lg flex">
+  <div class="navbar bg-base-100 shadow-lg flex z-20">
     <div class="flex-none">
       <!-- Toggle button for sidebar -->
       <button class="btn btn-square btn-ghost" @click="emit('toggle-sidebar')">

--- a/prototype/src/pages/CalendarPage.vue
+++ b/prototype/src/pages/CalendarPage.vue
@@ -1,5 +1,41 @@
-<template>
-  <div class="p-4">Calendar Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface Event {
+  date: string
+  title: string
+  description: string
+}
+
+const events = ref<Event[]>([])
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      events.value = data.events
+    }
+  } catch (err) {
+    console.error('Failed to load events', err)
+  }
+})
+</script>
+
+<template>
+  <div class="p-4 space-y-4">
+    <div
+      v-for="event in events"
+      :key="event.date"
+      class="collapse collapse-arrow bg-base-100 shadow"
+    >
+      <input type="checkbox" />
+      <div class="collapse-title font-medium">
+        {{ event.date }} - {{ event.title }}
+      </div>
+      <div class="collapse-content">
+        <p>{{ event.description }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/FriendsPage.vue
+++ b/prototype/src/pages/FriendsPage.vue
@@ -1,5 +1,46 @@
-<template>
-  <div class="p-4">Friends Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface Friend {
+  name: string
+  avatar: string
+  status: string
+}
+
+const friends = ref<Friend[]>([])
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      friends.value = data.friends
+    }
+  } catch (err) {
+    console.error('Failed to load friends', err)
+  }
+})
+</script>
+
+<template>
+  <div class="p-4">
+    <ul class="space-y-2">
+      <li
+        v-for="friend in friends"
+        :key="friend.name"
+        class="flex items-center gap-4 rounded-box bg-base-100 p-3 shadow"
+      >
+        <img
+          :src="friend.avatar"
+          :alt="friend.name"
+          class="h-12 w-12 rounded-full"
+        />
+        <div class="flex-1">
+          <div class="font-semibold">{{ friend.name }}</div>
+          <div class="text-sm opacity-60">{{ friend.status }}</div>
+        </div>
+        <button class="btn btn-sm">Message</button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/prototype/src/pages/GroupsPage.vue
+++ b/prototype/src/pages/GroupsPage.vue
@@ -1,5 +1,44 @@
-<template>
-  <div class="p-4">Groups Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface Group {
+  name: string
+  description: string
+  banner: string
+}
+
+const groups = ref<Group[]>([])
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      groups.value = data.groups
+    }
+  } catch (err) {
+    console.error('Failed to load groups', err)
+  }
+})
+</script>
+
+<template>
+  <div class="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      v-for="group in groups"
+      :key="group.name"
+      class="card bg-base-100 shadow-sm"
+    >
+      <figure>
+        <img :src="group.banner" :alt="group.name" />
+      </figure>
+      <div class="card-body">
+        <h2 class="card-title">{{ group.name }}</h2>
+        <p>{{ group.description }}</p>
+        <div class="card-actions justify-end">
+          <button class="btn btn-sm">Join</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/HomePage.vue
+++ b/prototype/src/pages/HomePage.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="p-4">
+  <div class="p-4 space-y-4">
+    <div class="hero rounded-box bg-base-200">
+      <div class="hero-content text-center">
+        <div class="max-w-md">
+          <h1 class="text-3xl font-bold">Welcome</h1>
+          <p class="py-2">Check out the latest posts below.</p>
+        </div>
+      </div>
+    </div>
     <div class="max-w-8xl w-full">
       <Feed />
     </div>

--- a/prototype/src/pages/MapPage.vue
+++ b/prototype/src/pages/MapPage.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="p-4 h-full">
-    <div id="map" class="w-full h-full rounded-box"></div>
+  <div class="p-4 h-full flex flex-col">
+    <div class="card flex-1 bg-base-100 shadow">
+      <div id="map" class="h-full w-full rounded-box"></div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import maplibregl, { Map } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -18,31 +20,32 @@ interface Location {
   description: string
 }
 
-const locations: Location[] = [
-  { id: 1, coordinates: [13.404954, 52.520008], title: 'Berlin', description: 'Berlin is the capital of Germany' },
-  { id: 2, coordinates: [11.581981, 48.135125], title: 'Munich', description: 'Munich is a city in Bavaria' },
-  { id: 3, coordinates: [9.993682, 53.551086], title: 'Hamburg', description: 'Hamburg is a port city' },
-  { id: 4, coordinates: [8.682127, 50.110924], title: 'Frankfurt', description: 'Frankfurt is a financial hub' },
-  { id: 5, coordinates: [6.960279, 50.937531], title: 'Cologne', description: 'Cologne is famous for its cathedral' }
-]
+const locations = ref<Location[]>([])
+let geojson: any
 
-const geojson = {
-  type: 'FeatureCollection',
-  features: locations.map((l) => ({
-    type: 'Feature',
-    properties: {
-      id: l.id,
-      title: l.title,
-      description: l.description
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: l.coordinates
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      locations.value = data.locations
+      geojson = {
+        type: 'FeatureCollection',
+        features: locations.value.map((l) => ({
+          type: 'Feature',
+          properties: {
+            id: l.id,
+            title: l.title,
+            description: l.description
+          },
+          geometry: { type: 'Point', coordinates: l.coordinates }
+        }))
+      }
     }
-  }))
-}
+  } catch (err) {
+    console.error('Failed to load locations', err)
+  }
 
-onMounted(() => {
   map = new maplibregl.Map({
     container: 'map',
     style: 'https://demotiles.maplibre.org/style.json',

--- a/prototype/src/pages/MarketPage.vue
+++ b/prototype/src/pages/MarketPage.vue
@@ -1,5 +1,42 @@
-<template>
-  <div class="p-4">Market Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface Item {
+  name: string
+  price: string
+  image: string
+}
+
+const items = ref<Item[]>([])
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      items.value = data.items
+    }
+  } catch (err) {
+    console.error('Failed to load items', err)
+  }
+})
+</script>
+
+<template>
+  <div class="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      v-for="item in items"
+      :key="item.name"
+      class="card bg-base-100 shadow-sm"
+    >
+      <figure><img :src="item.image" :alt="item.name" /></figure>
+      <div class="card-body">
+        <h2 class="card-title">{{ item.name }}</h2>
+        <p class="text-primary font-semibold">{{ item.price }}</p>
+        <div class="card-actions justify-end">
+          <button class="btn btn-sm">Buy</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/MessagesPage.vue
+++ b/prototype/src/pages/MessagesPage.vue
@@ -1,5 +1,54 @@
-<template>
-  <div class="p-4">Messages Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface Message {
+  from: 'me' | 'them'
+  text: string
+}
+
+const messages = ref<Message[]>([])
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      messages.value = data.messages
+    }
+  } catch (err) {
+    console.error('Failed to load messages', err)
+  }
+})
+const newMsg = ref('')
+
+function send() {
+  if (!newMsg.value) return
+  messages.value.push({ from: 'me', text: newMsg.value })
+  newMsg.value = ''
+}
+</script>
+
+<template>
+  <div class="p-4 flex flex-col gap-4 h-full">
+    <div class="flex-1 overflow-y-auto space-y-2">
+      <div
+        v-for="(msg, i) in messages"
+        :key="i"
+        class="chat"
+        :class="msg.from === 'me' ? 'chat-end' : 'chat-start'"
+      >
+        <div class="chat-bubble">{{ msg.text }}</div>
+      </div>
+    </div>
+    <div class="join">
+      <input
+        v-model="newMsg"
+        type="text"
+        placeholder="Type a message"
+        class="input input-bordered join-item flex-1"
+        @keyup.enter="send"
+      />
+      <button class="btn join-item" @click="send">Send</button>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/ProfilePage.vue
+++ b/prototype/src/pages/ProfilePage.vue
@@ -1,5 +1,40 @@
-<template>
-  <div class="p-4">Profile Page</div>
-</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
 
-<script setup lang="ts"></script>
+interface User {
+  name: string
+  bio: string
+  avatar: string
+}
+
+const user = ref<User | null>(null)
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (res.ok) {
+      const data = await res.json()
+      user.value = data.user
+    }
+  } catch (err) {
+    console.error('Failed to load user', err)
+  }
+})
+</script>
+
+<template>
+  <div class="p-4 flex justify-center">
+    <div v-if="user" class="card w-full max-w-md bg-base-100 shadow">
+      <figure class="px-10 pt-10">
+        <img :src="user.avatar" :alt="user.name" class="rounded-full w-32" />
+      </figure>
+      <div class="card-body items-center text-center">
+        <h2 class="card-title">{{ user.name }}</h2>
+        <p>{{ user.bio }}</p>
+        <div class="card-actions">
+          <button class="btn btn-sm">Follow</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/prototype/src/pages/SettingsPage.vue
+++ b/prototype/src/pages/SettingsPage.vue
@@ -1,5 +1,24 @@
-<template>
-  <div class="p-4">Settings Page</div>
-</template>
+<script setup lang="ts">
+import { ref } from 'vue'
 
-<script setup lang="ts"></script>
+const notifications = ref(true)
+const darkMode = ref(false)
+</script>
+
+<template>
+  <form class="p-4 space-y-4 max-w-md">
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">Enable notifications</span>
+        <input type="checkbox" v-model="notifications" class="toggle" />
+      </label>
+    </div>
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">Dark mode</span>
+        <input type="checkbox" v-model="darkMode" class="toggle" />
+      </label>
+    </div>
+    <button class="btn btn-primary btn-sm" type="submit">Save</button>
+  </form>
+</template>


### PR DESCRIPTION
## Summary
- embed DaisyUI hero on homepage
- add friend list, groups catalog, marketplace and other sample UI elements
- wrap map and build simple profile, settings and messages views
- fix navbar markup
- move all mock page data to single `posts.json`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68633877fad88327837b76b253f27f5f