### PR TITLE
Load events dynamically in calendar

### DIFF
--- a/prototype/src/pages/CalendarPage.vue
+++ b/prototype/src/pages/CalendarPage.vue
@@ -140,7 +140,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -149,77 +149,87 @@ import {
   EllipsisHorizontalIcon,
 } from '@heroicons/vue/20/solid'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
+import { ref, onMounted } from 'vue'
 
-const days = [
-  { date: '2021-12-27', events: [] },
-  { date: '2021-12-28', events: [] },
-  { date: '2021-12-29', events: [] },
-  { date: '2021-12-30', events: [] },
-  { date: '2021-12-31', events: [] },
-  { date: '2022-01-01', isCurrentMonth: true, events: [] },
-  { date: '2022-01-02', isCurrentMonth: true, events: [] },
-  {
-    date: '2022-01-03',
-    isCurrentMonth: true,
-    events: [
-      { id: 1, name: 'Design review', time: '10AM', datetime: '2022-01-03T10:00', href: '#' },
-      { id: 2, name: 'Sales meeting', time: '2PM', datetime: '2022-01-03T14:00', href: '#' },
-    ],
-  },
-  { date: '2022-01-04', isCurrentMonth: true, events: [] },
-  { date: '2022-01-05', isCurrentMonth: true, events: [] },
-  { date: '2022-01-06', isCurrentMonth: true, events: [] },
-  {
-    date: '2022-01-07',
-    isCurrentMonth: true,
-    events: [{ id: 3, name: 'Date night', time: '6PM', datetime: '2022-01-08T18:00', href: '#' }],
-  },
-  { date: '2022-01-08', isCurrentMonth: true, events: [] },
-  { date: '2022-01-09', isCurrentMonth: true, events: [] },
-  { date: '2022-01-10', isCurrentMonth: true, events: [] },
-  { date: '2022-01-11', isCurrentMonth: true, events: [] },
-  {
-    date: '2022-01-12',
-    isCurrentMonth: true,
-    isToday: true,
-    events: [{ id: 6, name: "Sam's birthday party", time: '2PM', datetime: '2022-01-25T14:00', href: '#' }],
-  },
-  { date: '2022-01-13', isCurrentMonth: true, events: [] },
-  { date: '2022-01-14', isCurrentMonth: true, events: [] },
-  { date: '2022-01-15', isCurrentMonth: true, events: [] },
-  { date: '2022-01-16', isCurrentMonth: true, events: [] },
-  { date: '2022-01-17', isCurrentMonth: true, events: [] },
-  { date: '2022-01-18', isCurrentMonth: true, events: [] },
-  { date: '2022-01-19', isCurrentMonth: true, events: [] },
-  { date: '2022-01-20', isCurrentMonth: true, events: [] },
-  { date: '2022-01-21', isCurrentMonth: true, events: [] },
-  {
-    date: '2022-01-22',
-    isCurrentMonth: true,
-    isSelected: true,
-    events: [
-      { id: 4, name: 'Maple syrup museum', time: '3PM', datetime: '2022-01-22T15:00', href: '#' },
-      { id: 5, name: 'Hockey game', time: '7PM', datetime: '2022-01-22T19:00', href: '#' },
-    ],
-  },
-  { date: '2022-01-23', isCurrentMonth: true, events: [] },
-  { date: '2022-01-24', isCurrentMonth: true, events: [] },
-  { date: '2022-01-25', isCurrentMonth: true, events: [] },
-  { date: '2022-01-26', isCurrentMonth: true, events: [] },
-  { date: '2022-01-27', isCurrentMonth: true, events: [] },
-  { date: '2022-01-28', isCurrentMonth: true, events: [] },
-  { date: '2022-01-29', isCurrentMonth: true, events: [] },
-  { date: '2022-01-30', isCurrentMonth: true, events: [] },
-  { date: '2022-01-31', isCurrentMonth: true, events: [] },
-  { date: '2022-02-01', events: [] },
-  { date: '2022-02-02', events: [] },
-  { date: '2022-02-03', events: [] },
-  {
-    date: '2022-02-04',
-    events: [{ id: 7, name: 'Cinema with friends', time: '9PM', datetime: '2022-02-04T21:00', href: '#' }],
-  },
-  { date: '2022-02-05', events: [] },
-  { date: '2022-02-06', events: [] },
-]
-const selectedDay = days.find((day) => day.isSelected)
+interface CalendarEvent {
+  id: number
+  name: string
+  time: string
+  datetime: string
+  href: string
+}
+
+interface Day {
+  date: string
+  isCurrentMonth?: boolean
+  isToday?: boolean
+  isSelected?: boolean
+  events: CalendarEvent[]
+}
+
+const days = ref<Day[]>([])
+const selectedDay = ref<Day | undefined>(undefined)
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/posts.json')
+    if (!res.ok) return
+
+    const data = await res.json()
+    const ev = Array.isArray(data.events) ? data.events : []
+
+    let year: number, month: number
+    if (ev.length > 0) {
+      const [y, m] = ev[0].date.split('-').map((v: string) => parseInt(v, 10))
+      year = y
+      month = m - 1
+    } else {
+      const now = new Date()
+      year = now.getFullYear()
+      month = now.getMonth()
+    }
+
+    const firstOfMonth = new Date(year, month, 1)
+    const offset = (firstOfMonth.getDay() + 6) % 7
+    const startDate = new Date(year, month, 1 - offset)
+
+    const arr: Day[] = []
+    for (let i = 0; i < 42; i++) {
+      const d = new Date(startDate)
+      d.setDate(startDate.getDate() + i)
+      const iso = d.toISOString().split('T')[0]
+      const events = ev
+        .filter((e: any) => e.date === iso)
+        .map((e: any, idx: number) => ({
+          id: idx + 1,
+          name: e.title,
+          time: '',
+          datetime: `${e.date}T00:00`,
+          href: '#',
+        }))
+
+      arr.push({
+        date: iso,
+        isCurrentMonth: d.getMonth() === month,
+        isToday: iso === new Date().toISOString().split('T')[0],
+        events,
+      })
+    }
+
+    const firstEventDate = ev[0]?.date
+    if (firstEventDate) {
+      const d = arr.find((day) => day.date === firstEventDate)
+      if (d) {
+        d.isSelected = true
+        selectedDay.value = d
+      }
+    } else {
+      selectedDay.value = arr.find((day) => day.isToday)
+    }
+
+    days.value = arr
+  } catch (err) {
+    console.error('Failed to load events', err)
+  }
+})
 </script>


### PR DESCRIPTION
## Summary
- fetch events from `posts.json` for the calendar
- generate calendar days dynamically using the fetched events
- highlight the first event date

## Testing
- `pnpm install --prefix prototype`
- `pnpm --prefix prototype run dev`

------
https://chatgpt.com/codex/tasks/task_e_686544a0bef8832789f209447dd7a7a5